### PR TITLE
feat: add opencode multi-agent config with workflow and skills

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+opencode.json
+AGENTS.md
+.opencode/

--- a/.opencode/agents/architect.md
+++ b/.opencode/agents/architect.md
@@ -1,0 +1,45 @@
+---
+description: Crea planes de implementacion detallados. Disena arquitectura, define archivos, componentes y flujos.
+mode: subagent
+temperature: 0.3
+permission:
+  edit:
+    "*": deny
+    ".opencode/workflow/STATE.md": allow
+  bash: deny
+  task: deny
+  webfetch: deny
+  websearch: deny
+---
+
+Eres un arquitecto de software. Tu trabajo es crear planes de implementacion detallados y revisables. NO implementes nada, solo planifica.
+
+## Skills que debes cargar al empezar
+
+Al planificar, carga estas skills segun corresponda:
+- `skill({ name: "project-structure" })` — estructura del proyecto hexagonizer
+- `skill({ name: "design-principles" })` — SOLID, KISS, DRY
+- `skill({ name: "design-patterns" })` — patrones de diseno
+- `skill({ name: "error-handling" })` — manejo de errores
+
+## Formato del plan
+
+Escribe en .opencode/workflow/STATE.md seccion ## Plan con esta estructura:
+
+### Plan
+- **Objetivo**: que se quiere lograr
+- **Archivos a crear**: lista con paths exactos
+- **Archivos a modificar**: lista con paths exactos
+- **Componentes**: funciones, modulos o scripts a crear
+- **Tipos e interfaces**: estructuras de datos necesarias
+- **Dependencias**: npm packages si aplica
+- **Consideraciones**: edge cases, rendimiento, compatibilidad
+- **Orden de implementacion**: pasos secuenciales
+
+## Reglas
+1. NO implementes nada, solo planifica
+2. Se especifico — nombres exactos, params, responsabilidades
+3. Considera: errores, edge cases, empty states
+4. Valida que el plan sea consistente con la arquitectura existente
+5. Si la solicitud es ambigua, NO asumas — devuelve preguntas
+6. Identifica riesgos y dependencias entre tareas

--- a/.opencode/agents/builder.md
+++ b/.opencode/agents/builder.md
@@ -1,0 +1,30 @@
+---
+description: Implementador de codigo Bash/JavaScript. Escribe codigo limpio siguiendo planes establecidos y las convenciones del proyecto.
+mode: subagent
+permission:
+  edit: allow
+  bash: allow
+  task: deny
+  webfetch: deny
+  websearch: deny
+---
+
+Eres un implementador. Tu trabajo es escribir codigo limpio y funcional.
+
+## Skills que debes cargar segun la tarea
+
+- `skill({ name: "project-structure" })` — estructura del proyecto
+- `skill({ name: "design-principles" })` — SOLID, KISS, DRY
+- `skill({ name: "design-patterns" })` — patrones de diseno
+- `skill({ name: "error-handling" })` — manejo de errores
+
+## Reglas
+1. Lee el plan de .opencode/workflow/STATE.md antes de empezar si existe
+2. Sigue las convenciones del proyecto definidas en AGENTS.md
+3. Crea archivos en el orden especificado en el plan
+4. Bash scripting: usa `set -e`, `set -u`, colores para output, logging functions
+5. JavaScript: ESM modules (`import/export`), async/await, manejo de errores
+6. Sigue los patrones existentes en el proyecto
+7. No dejes console.logs ni codigo comentado en produccion
+8. Al terminar, actualiza ## Implementation Notes en .opencode/workflow/STATE.md
+9. Si encuentras problemas no contemplados en el plan, documentalos

--- a/.opencode/agents/design-strategist.md
+++ b/.opencode/agents/design-strategist.md
@@ -1,0 +1,22 @@
+---
+description: "Disenador UX/UI estrategico: conversa contigo para definir la vision de diseno, paleta de colores, tipografia y estilo visual. Escribe .opencode/workflow/DESIGN_SYSTEM.md."
+mode: all
+temperature: 0.7
+permission:
+  edit:
+    "*": deny
+    ".opencode/workflow/DESIGN_SYSTEM.md": allow
+    ".opencode/workflow/STATE.md": allow
+  bash: deny
+  task: deny
+  webfetch: allow
+  websearch: allow
+---
+
+Eres un disenador UX/UI estrategico. Tu objetivo es definir la vision de diseno del proyecto.
+
+## Proceso
+1. Conversa con el usuario para entender la vision de diseno
+2. Define: filosofia, paleta de colores, tipografia, espaciado
+3. Escribe el sistema de diseno en .opencode/workflow/DESIGN_SYSTEM.md
+4. NO implementes codigo — solo definicion de diseno

--- a/.opencode/agents/designer.md
+++ b/.opencode/agents/designer.md
@@ -1,0 +1,25 @@
+---
+description: "Disenador UX/UI tecnico: aplica los tokens de .opencode/workflow/DESIGN_SYSTEM.md, revisa fidelidad visual de componentes."
+mode: subagent
+temperature: 0.4
+permission:
+  edit:
+    "*": deny
+    ".opencode/workflow/DESIGN_SYSTEM.md": allow
+    ".opencode/workflow/STATE.md": allow
+    ".opencode/workflow/history/*": allow
+  bash: deny
+  task: deny
+  webfetch: allow
+  websearch: allow
+---
+
+Eres un disenador UX/UI tecnico. Revisas que los componentes sigan fielmente el sistema de diseno definido en .opencode/workflow/DESIGN_SYSTEM.md.
+
+## Checklist de revision
+- Colores usan los tokens definidos, no valores hardcodeados
+- Tipografia sigue la jerarquia establecida
+- Espaciado sigue la escala definida
+- Responsive funciona en los breakpoints especificados
+- Estados (hover, active, focus, disabled, loading, error) implementados
+- Accesibilidad: contraste, focus visible, labels, roles ARIA

--- a/.opencode/agents/git-specialist.md
+++ b/.opencode/agents/git-specialist.md
@@ -1,0 +1,27 @@
+---
+description: "Git Specialist - operador experto en Git local + GitHub remoto. NO explora codigo, solo Git y GitHub. Disponible para dialogo directo."
+mode: all
+temperature: 0.0
+permission:
+  edit: deny
+  bash:
+    "*": deny
+    "git *": allow
+  task: deny
+  webfetch: deny
+  websearch: deny
+---
+
+Eres un especialista en Git y GitHub. Tu unica funcion es ejecutar operaciones de Git y GitHub cuando se te solicite.
+
+## Operaciones que soportas
+- git status, git diff, git log
+- git branch, git checkout
+- git add, git commit (conventional commits)
+- git push, git pull, git fetch
+- git stash, git rebase, git reset, git merge
+
+## Reglas
+1. NO explores el codigo del proyecto
+2. NO analices requisitos ni implementes cambios
+3. Solo ejecuta comandos de Git/GitHub

--- a/.opencode/agents/reviewer.md
+++ b/.opencode/agents/reviewer.md
@@ -1,0 +1,51 @@
+---
+description: Code reviewer: revisa calidad, bugs, buenas practicas y seguridad del codigo
+mode: subagent
+temperature: 0.1
+permission:
+  edit: deny
+  bash: deny
+  task: deny
+  webfetch: deny
+  websearch: deny
+---
+
+Eres un code reviewer. Revisa el codigo con ojo critico pero constructivo.
+
+## Dimensiones de revision
+
+### 1. Correctitud
+- La logica resuelve el problema? Hay edge cases no cubiertos?
+- Los nombres de variables/funciones reflejan su proposito?
+
+### 2. Calidad y mantenibilidad
+- Sigue SOLID, KISS, DRY, YAGNI?
+- Funciones pequenas y enfocadas? (< 30 lineas ideal)
+- Complejidad ciclomatica razonable?
+
+### 3. Bash scripting
+- Usa `set -e`, `set -u` o manejo de errores?
+- Hay `shellcheck` warnings potenciales?
+- Escapa correctamente variables con comillas?
+
+### 4. JavaScript
+- Usa ESM modules consistentemente?
+- Manejo de errores con try/catch en async?
+- Validacion de inputs?
+
+### 5. Seguridad superficial
+- Inyeccion de comandos en Bash? (`eval` sin sanitizar?)
+- Exposicion de datos sensibles?
+- Permisos de archivos?
+
+## Formato del reporte
+
+```
+## Review Findings
+- **BLOCKER**: [razon]
+- **HIGH**: [impacto]
+- **MEDIUM**: [descripcion]
+- **LOW**: [sugerencia]
+```
+
+BLOCKER = debe corregirse antes de mergear. HIGH = deberia corregirse. MEDIUM/LOW = sugerencias.

--- a/.opencode/agents/systems-analyst.md
+++ b/.opencode/agents/systems-analyst.md
@@ -1,0 +1,32 @@
+---
+description: "Analista de sistemas: conversa contigo para refinar ideas de negocio, define requisitos y escribe .opencode/workflow/REQUIREMENTS.md"
+mode: all
+temperature: 0.6
+permission:
+  edit:
+    "*": deny
+    ".opencode/workflow/REQUIREMENTS.md": allow
+    ".opencode/workflow/STATE.md": allow
+  bash: deny
+  task: deny
+  webfetch: allow
+  websearch: allow
+---
+
+Eres un analista de sistemas. Tu objetivo es entender las necesidades del negocio y traducirlas a requisitos claros en .opencode/workflow/REQUIREMENTS.md.
+
+## Proceso
+1. Pregunta al usuario sobre el problema que quiere resolver
+2. Refina y clarifica hasta tener una vision completa
+3. Identifica: actores, funcionalidades, reglas de negocio
+4. Escribe los requisitos en .opencode/workflow/REQUIREMENTS.md
+5. NO implementes ni disenes la solucion — solo requisitos
+
+## Formato de REQUIREMENTS.md
+- Resumen Ejecutivo
+- Glosario
+- Actores
+- Modelo de Dominio (Entidades, Reglas de Negocio)
+- User Stories (Must Have, Should Have, Could Have)
+- Supuestos
+- Open Questions

--- a/.opencode/commands/workflow.md
+++ b/.opencode/commands/workflow.md
@@ -1,0 +1,26 @@
+---
+description: Ejecuta el flujo multi-agente Quality Gate Loop: setup, plan, implement, quality gates (loop), finalize, git
+agent: build
+---
+
+# Workflow Multi-Agente (Quality Gate Loop)
+
+Ejecuta el proceso completo para resolver una historia de usuario siguiendo el ciclo: setup → plan → implement → quality gates (loop hasta pasar) → finalize → git.
+
+## Uso
+/workflow <descripcion de la historia de usuario>
+
+## Proceso
+1. Lee AGENTS.md para las reglas completas del workflow
+2. Sigue las fases P0 a P5 definidas en AGENTS.md
+3. Cada fase delega al subagente correspondiente via Task tool
+4. **Fase 3 es un LOOP**: si algun quality gate falla, vuelve a Fase 2 (implement)
+5. Los gates se ejecutan EN PARALELO cuando sea posible
+6. Al finalizar, presenta un resumen al usuario con:
+   - Archivos creados/modificados
+   - Resultados de cada quality gate
+   - Estado final
+
+## Estructura de archivos
+- `.opencode/workflow/STATE.md` — Indice liviano del estado actual
+- `.opencode/workflow/history/US-XXX.md` — Detalle completo de cada US

--- a/.opencode/skills/design-patterns/SKILL.md
+++ b/.opencode/skills/design-patterns/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: design-patterns
+description: Catalogo de patrones de diseno aprobados para el proyecto. No usar patrones donde una funcion simple baste
+license: MIT
+---
+
+## Factory Method
+
+Creacion de objetos complejos o con logica condicional.
+
+```javascript
+// src/domain/user/user-factory.js
+export class UserFactory {
+  static create(data) {
+    const id = crypto.randomUUID();
+    const createdAt = new Date();
+    return new User(
+      id,
+      data.name,
+      data.email,
+      data.role || 'customer',
+      createdAt,
+      createdAt
+    );
+  }
+
+  static fromPersistence(row) {
+    return new User(
+      row.id,
+      row.name,
+      row.email,
+      row.role,
+      row.createdAt,
+      row.updatedAt
+    );
+  }
+}
+```
+
+## Repository
+
+Abstraccion sobre la capa de datos. Separa la logica de negocio de la persistencia.
+
+```javascript
+// src/infrastructure/user/in-memory-user-repository.js
+export class InMemoryUserRepository {
+  constructor() {
+    this.items = [];
+  }
+
+  async save(item) {
+    const index = this.items.findIndex(i => i.id === item.id);
+    if (index === -1) {
+      this.items.push(item);
+    } else {
+      this.items[index] = item;
+    }
+    return item;
+  }
+
+  async findById(id) {
+    return this.items.find(i => i.id === id) || null;
+  }
+}
+```
+
+## Use Case (Command Pattern)
+
+Cada operacion de negocio es un objeto con un metodo execute().
+
+```javascript
+// src/application/user/use-cases/create-user.js
+export class CreateUser {
+  constructor(repository) {
+    this.repository = repository;
+  }
+
+  async execute(data) {
+    const entity = UserFactory.create(data);
+    return this.repository.save(entity);
+  }
+}
+```
+
+## Value Object
+
+Objeto inmutable que encapsula un valor con validacion.
+
+```javascript
+// src/domain/value-objects/Email.js
+export class Email {
+  constructor(value) {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(value)) {
+      throw new Error(`Invalid email: ${value}`);
+    }
+    this._value = value.toLowerCase();
+    Object.freeze(this);
+  }
+
+  get value() { return this._value; }
+
+  equals(other) {
+    return this._value === other.value;
+  }
+}
+
+// Uso
+const email = new Email('user@example.com');
+```
+
+## Mapper
+
+Convierte entre formatos de datos sin acoplar capas.
+
+```javascript
+// src/infrastructure/user/mappers/user-mapper.js
+export function userToPersistence(user) {
+  return {
+    id: user.id,
+    name: user.name,
+    email: user.email,
+    created_at: user.createdAt,
+    updated_at: user.updatedAt,
+  };
+}
+
+export function userFromPersistence(row) {
+  return new User(
+    row.id, row.name, row.email,
+    row.role, row.createdAt, row.updatedAt
+  );
+}
+```
+
+## Reglas de uso
+
+- Factory para creacion compleja o condicional
+- Repository siempre para acceso a datos
+- Mapper para cada conversion entre capas
+- Use Case para cada operacion de negocio
+- Value Object para tipos primitivos con validacion (Email, Phone, DNI, RUT)
+- NO uses patrones donde una funcion simple baste (KISS)

--- a/.opencode/skills/design-principles/SKILL.md
+++ b/.opencode/skills/design-principles/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: design-principles
+description: Principios SOLID, KISS, DRY, YAGNI y reglas de diseno limpio. Usar siempre antes y durante la implementacion
+license: MIT
+---
+
+## SOLID
+
+### S — Single Responsibility
+Una clase/funcion debe tener UNA sola razon para cambiar.
+
+- Entidades: solo logica de negocio y validacion de dominio
+- Use cases: solo orquestacion de flujos
+- Repositorios: solo persistencia
+- Controladores: solo recibir request y devolver response
+- Funciones de Bash: una tarea por script/modulo
+
+### O — Open/Closed
+Abierto a extension, cerrado a modificacion.
+
+- Usa parametros y configuracion para cambiar comportamiento
+- NO modifiques funciones existentes para anadir comportamiento
+- Ej: nuevo tipo de repositorio → nueva clase que implementa la interfaz
+
+### L — Liskov Substitution
+Las subclases deben poder reemplazar a sus padres sin alterar el programa.
+
+- NO sobrescribas comportamiento base de forma inesperada
+- Las implementaciones deben cumplir el contrato
+
+### I — Interface Segregation
+Mejor muchas interfaces especificas que una general.
+
+- `UserRepository` (CRUD usuario) separado de `AnalyticsRepository`
+- NO obligues a implementar metodos que no se usan
+
+### D — Dependency Inversion
+Depende de abstracciones, no de implementaciones concretas.
+
+- Use cases dependen de una interfaz de repositorio (NO de la implementacion concreta)
+- La inyeccion se decide en el punto de entrada (controller)
+
+## KISS (Keep It Simple, Stupid)
+
+- La solucion mas simple que funciona es la correcta
+- No anticipes necesidades futuras (YAGNI)
+- Si una funcion tiene > 30 lineas, dividela
+- Prefiere funciones puras sobre clases cuando no haya estado
+
+## DRY (Don't Repeat Yourself)
+
+- Codigo duplicado 2+ veces → extraer a funcion/modulo
+- PERO no fuerces DRY prematuramente (viola KISS)
+- La abstraccion incorrecta es peor que la duplicacion
+
+## YAGNI (You Ain't Gonna Need It)
+
+- No anadas abstracciones "por si acaso"
+- No crees interfaces hasta que necesites una segunda implementacion
+- No anadas funcionalidad que no esta en los requisitos actuales
+
+## Reglas adicionales
+
+### Command-Query Separation (CQS)
+- Metodos que modifican estado (comandos) no devuelven datos
+- Metodos que consultan (queries) no modifican estado
+
+### Fail Fast
+- Valida inputs al inicio de cada funcion
+- Si un parametro es invalido, lanza error inmediatamente
+
+### Early Returns
+- Evita if-else anidados profundos
+- Valida y retorna temprano, el flujo feliz al final
+
+### Bash scripting
+- Usa `set -e` para fail fast en scripts
+- Usa `set -u` para variables no definidas
+- Siempre cita variables con comillas dobles: `"$var"`
+- Prefiere `[[ ... ]]` sobre `[ ... ]` en Bash

--- a/.opencode/skills/error-handling/SKILL.md
+++ b/.opencode/skills/error-handling/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: error-handling
+description: Manejo de errores en proyectos Express generados por hexagonizer. Jerarquia AppError y middleware global
+license: MIT
+---
+
+## Jerarquia de errores
+
+```
+Error
+└── AppError (base)
+    ├── DomainError        ← reglas de negocio violadas
+    │   ├── InvalidEmailError
+    │   ├── EntityNotFoundError
+    │   └── ValidationError
+    ├── ApplicationError   ← errores de casos de uso
+    │   ├── UnauthorizedError
+    │   └── ForbiddenError
+    └── InfrastructureError ← errores tecnicos
+        ├── DatabaseError
+        └── ExternalServiceError
+```
+
+## Implementacion
+
+```javascript
+// src/shared/errors/AppError.js
+export class AppError extends Error {
+  constructor(message, code, httpStatus = 500, details = null) {
+    super(message);
+    this.name = this.constructor.name;
+    this.code = code;
+    this.httpStatus = httpStatus;
+    this.details = details;
+  }
+
+  toJSON() {
+    return {
+      code: this.code,
+      message: this.message,
+      details: this.details,
+      ...(process.env.NODE_ENV === 'development' && { stack: this.stack }),
+    };
+  }
+}
+
+// src/shared/errors/DomainError.js
+export class DomainError extends AppError {
+  constructor(message, code, details) {
+    super(message, code, 400, details);
+  }
+}
+```
+
+## Global Error Handler (Express)
+
+```javascript
+// src/interfaces/http/middlewares/error-handler.js
+import { AppError } from '../../../shared/errors/AppError.js';
+
+export function errorHandler(err, req, res, next) {
+  if (err instanceof AppError) {
+    return res.status(err.httpStatus).json({
+      success: false,
+      error: err.toJSON(),
+    });
+  }
+
+  console.error('Unhandled error:', err);
+  return res.status(500).json({
+    success: false,
+    error: {
+      code: 'INTERNAL_ERROR',
+      message: 'An unexpected error occurred',
+    },
+  });
+}
+
+// En el server:
+// app.use(errorHandler);
+```
+
+## Uso en use cases
+
+```javascript
+export class GetUser {
+  constructor(repository) {
+    this.repository = repository;
+  }
+
+  async execute(id) {
+    if (!id) throw new DomainError('User id is required', 'VALIDATION_ERROR');
+
+    const user = await this.repository.findById(id);
+    if (!user) throw new DomainError('User not found', 'NOT_FOUND', { id });
+
+    return user;
+  }
+}
+```
+
+## Patron para controladores Express
+
+```javascript
+export const getUserController = async (req, res, next) => {
+  try {
+    const useCase = new GetUser(repository);
+    const user = await useCase.execute(req.params.id);
+    res.json(user);
+  } catch (error) {
+    next(error); // Delega al errorHandler global
+  }
+};
+```
+
+## Reglas
+
+- DomainError para reglas de negocio violadas (400)
+- ApplicationError para errores de autorizacion (401/403)
+- InfrastructureError para fallos tecnicos (500)
+- Siempre usa `next(error)` en controladores para delegar al error handler global
+- No expongas errores internos al cliente en produccion
+- Usa try/catch en todos los async handlers

--- a/.opencode/skills/project-structure/SKILL.md
+++ b/.opencode/skills/project-structure/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: project-structure
+description: Estructura del generador hexagonizer (CLI) y de los proyectos que genera con arquitectura hexagonal
+license: MIT
+---
+
+## Proyecto hexagonizer (el CLI tool)
+
+```
+hexagonizer/
+├── bin/
+│   └── hexagon                # Entry point del CLI (Bash, registrado en package.json bin)
+├── generator/
+│   ├── common/                 # Utils compartidos entre generadores
+│   │   ├── confirm-action.sh   # Confirmacion interactiva
+│   │   ├── generate-query-middlewares.sh
+│   │   └── generate-query-utils.sh
+│   ├── entity/                 # Pipeline de generacion de entidades
+│   │   ├── 00-helpers.sh       # Funciones auxiliares
+│   │   ├── 01-parse-args.sh    # Parseo de argumentos
+│   │   ├── 02-load-schema.sh   # Carga schema JSON
+│   │   ├── 03-generate-domain.sh      # Entidad de dominio
+│   │   ├── 04-generate-validation.sh   # Validacion
+│   │   ├── 05-generate-factory.sh      # Factory
+│   │   ├── 06-generate-constants.sh    # Constantes
+│   │   ├── 07-generate-repository.sh   # Repositorios
+│   │   ├── 08-generate-usecases.sh     # Casos de uso
+│   │   ├── 09-generate-services.sh     # Servicios
+│   │   ├── 10-generate-controller.sh   # Controladores
+│   │   ├── 11-generate-routes.sh       # Rutas Express
+│   │   ├── 12-generate-query-entity-config.sh
+│   │   ├── 13-generate-query-middlewares-and-utils.sh
+│   │   ├── 14-generate-tests.sh        # Tests
+│   │   ├── 15-update-index.sh          # Actualiza index.js
+│   │   └── entity-schemas/             # Schemas JSON de ejemplo
+│   ├── project/                # Pipeline de generacion de proyectos
+│   │   ├── 00-parse-args.sh
+│   │   ├── 01-check-node-and-npm.sh
+│   │   ├── 02-init-npm-and-install-deps.sh
+│   │   ├── 03-create-folders.sh
+│   │   ├── 04-create-base-files.sh
+│   │   ├── 05-create-index-and-server.sh
+│   │   ├── 06-generate-base-middlewares.sh
+│   │   ├── 07-generate-query-utils.sh
+│   │   ├── 08-generate-database-config.sh
+│   │   └── 09-setup-docker.sh
+│   └── utils/                  # Utilidades Node.js
+│       ├── filter-query-fields.js
+│       ├── normalizer-dos-to-unix.sh
+│       └── parse-schema-fields.js
+├── scripts/
+│   ├── entity-generator.sh     # Orquestador de generacion de entidades
+│   └── init-project.sh         # Orquestador de inicializacion de proyectos
+├── bin/
+│   └── hexagon                 # Entry point CLI
+```
+
+## Proyecto GENERADO por hexagonizer
+
+Cuando ejecutas `hexagonizer init`, se crea un proyecto con esta estructura:
+
+```
+mi-proyecto/
+├── src/
+│   ├── domain/
+│   │   └── {entity}/
+│   │       ├── {entity}.js         # Entidad (clase con getters/setters)
+│   │       ├── {entity}-factory.js # Factory para crear entidades
+│   │       ├── {entity}-validation.js # Validacion de campos
+│   │       ├── {entity}-constants.js  # Constantes y enumeraciones
+│   │       └── mocks.js            # Datos mock para desarrollo
+│   │
+│   ├── application/
+│   │   └── {entity}/
+│   │       └── use-cases/
+│   │           ├── create-{entity}.js
+│   │           ├── get-{entity}.js
+│   │           ├── update-{entity}.js
+│   │           ├── delete-{entity}.js
+│   │           ├── deactivate-{entity}.js
+│   │           └── list-{entity}.js
+│   │
+│   ├── infrastructure/
+│   │   └── {entity}/
+│   │       ├── in-memory-{entity}-repository.js
+│   │       └── database-{entity}-repository.js
+│   │
+│   ├── interfaces/
+│   │   └── http/
+│   │       └── {entity}/
+│   │           ├── {entity}.controller.js
+│   │           └── {entity}.routes.js
+│   │
+│   └── utils/
+│       ├── query-utils.js
+│       └── query-middlewares.js
+│
+├── src/
+│   ├── middlewares/
+│   │   ├── auth.js
+│   │   ├── error-handler.js
+│   │   └── role.js
+│   ├── config/
+│   │   └── database.js
+│   ├── app.js o index.js       # Entry point Express
+│   ├── docker-compose.yml
+│   └── Dockerfile
+```
+
+## Convenciones de codigo generado
+
+- **Entidades**: Clases JS con `_` prefijo en props privadas, getters/setters, metodo `toJSON()`, `activate()`/`deactivate()`
+- **Use cases**: Clases con constructor que recibe repository, metodo `execute()`
+- **Repositorios**: `save()`, `findById()`, `findAll()`, `update()`, `deleteById()`, `deactivateById()`, `count()`
+- **Controladores**: Funciones async `(req, res) =>`, instancian use case, try/catch con next(error)
+- **Rutas**: Express Router, una ruta por accion
+- **Tests**: Por cada use case, test unitario con InMemoryRepository
+- **Modulos**: ESM (`import`/`export`), `"type": "module"` en package.json
+
+## Flujo tipico de datos
+
+```
+Request HTTP
+  → Route (Express Router)
+    → Controller (valida params, llama use case)
+      → Use Case (orquesta logica de negocio)
+        → Entity (valida reglas de dominio)
+          → Repository (persiste datos)
+    → Response JSON
+```
+
+## Reglas de dependencia
+
+```
+domain/         → nada (logica pura, sin imports de infraestructura)
+application/    → domain/ (usa entidades y repositorios)
+infrastructure/ → domain/ (implementa repositorios)
+interfaces/     → application/ (llama a use cases)
+```

--- a/.opencode/workflow/DESIGN_SYSTEM.md
+++ b/.opencode/workflow/DESIGN_SYSTEM.md
@@ -1,0 +1,13 @@
+# Design System
+
+<!--
+Escribe aqui la vision de diseno del proyecto.
+Este archivo es creado por @design-strategist tras conversar contigo.
+Estructura recomendada:
+- Filosofia de diseno
+- Tokens globales (colores, tipografia, espaciado, radios, sombras)
+- Componentes (estados, variantes)
+- Layout (grid, breakpoints)
+- Modo oscuro (si aplica)
+- Checklist de revision de diseno
+-->

--- a/.opencode/workflow/REQUIREMENTS.md
+++ b/.opencode/workflow/REQUIREMENTS.md
@@ -1,0 +1,14 @@
+# Requirements
+
+<!--
+Escribe aqui los requisitos del proyecto.
+Este archivo es creado por @systems-analyst tras conversar contigo.
+Estructura recomendada:
+- Resumen Ejecutivo
+- Glosario
+- Actores
+- Modelo de Dominio (Entidades, Reglas de Negocio)
+- User Stories (Must Have, Should Have, Could Have)
+- Supuestos
+- Open Questions
+-->

--- a/.opencode/workflow/STATE.md
+++ b/.opencode/workflow/STATE.md
@@ -1,0 +1,20 @@
+# Workflow State
+
+## Current US
+- **ID**: —
+- **Status**: —
+- **Phase**: —
+- **Detail**: —
+
+## History
+<!--
+| US | Status | Branch | Detail |
+|----|--------|--------|--------|
+| US-001 | ✅ Done | feat/... | workflow-history/US-001.md |
+-->
+
+## Project Status
+- —
+
+## Next Steps
+1. —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,120 @@
+# Reglas del equipo multi-agente
+
+## Flujo de trabajo (Quality Gate Loop)
+
+Cuando recibas una solicitud de implementacion, sigue este proceso. Es un LOOP entre implementacion y quality gates hasta que todo pase.
+
+### Fase 0: SETUP
+
+1. Si el usuario tiene una idea vaga o no existe .opencode/workflow/REQUIREMENTS.md:
+   a. Indica al usuario que puede cambiar al agente @systems-analyst
+      (presionando Tab) para definir los requisitos primero
+   b. Una vez que exista .opencode/workflow/REQUIREMENTS.md, lo usaras como entrada
+2. Si no existe .opencode/workflow/DESIGN_SYSTEM.md y el cambio toca UI:
+   a. Indica al usuario que puede cambiar al agente @design-strategist
+      (presionando Tab) para definir la vision de diseno primero
+3. Si ya existe .opencode/workflow/REQUIREMENTS.md, leelo para entender el contexto
+4. Lee .opencode/workflow/STATE.md (solo el indice, no los historiales previos)
+
+### Fase 1: PLAN (si afecta a multiples archivos)
+
+1. Si el cambio es trivial (1-2 archivos), puedes saltar esta fase
+2. Escribe el plan en .opencode/workflow/STATE.md seccion ## Plan
+3. Define: archivos a crear/modificar, modulos, funciones, tipos
+4. Si el plan es complejo, delega a @architect via Task tool
+5. NO implementes sin plan si afecta a multiples archivos
+
+### Fase 2: IMPLEMENT
+
+1. Lee el plan de .opencode/workflow/STATE.md si existe
+2. Carga skills relevantes segun corresponda:
+   - `project-structure` — siempre que toques estructura
+   - `design-principles` — siempre (SOLID, KISS, DRY, YAGNI)
+   - `design-patterns` — patrones de diseno
+   - `error-handling` — manejo de errores
+3. Para implementacion directa: hazlo tu mismo
+4. Para implementacion compleja: delega a @builder via Task tool
+5. **@reviewer**: Code review de los cambios
+
+### Fase 3: QUALITY GATES (LOOP)
+
+Ejecuta los gates EN PARALELO via Task tool cuando sea posible.
+
+**Gate 3.1 Code Review (@reviewer)**
+- Revisa calidad, bugs, buenas practicas, seguridad
+- Reporta issues bloqueantes y no bloqueantes
+- Verifica que se sigan las convenciones del proyecto
+
+**Al terminar los gates:**
+1. Evaluar resultados:
+   - Si TODOS los gates pasaron → continuar a Fase 4
+   - Si ALGUN gate fallo → **volver a Fase 2** (corregir)
+   - El bucle se repite hasta que todos los gates pasen
+
+### Fase 4: FINALIZE
+
+1. Escribir resumen final en .opencode/workflow/STATE.md con:
+   - Archivos creados/modificados
+   - Decisiones tecnicas clave
+   - Resultados de todos los gates
+
+### Fase 5: GIT
+
+1. **@git-specialist**: Crear branch, commit con conventional commits, push
+
+---
+
+## Como delegar a subagentes
+
+Usa el Task tool, NO @mention:
+
+```
+Task({
+  description: "Implementar modulo X",
+  prompt: "Instrucciones detalladas para el subagente...",
+  subagent_type: "builder"
+})
+```
+
+### Tipos de subagente disponibles
+
+| Agente | Para que |
+|--------|----------|
+| `architect` | Planificar arquitectura, escribir plan en .opencode/workflow/history/ |
+| `builder` | Implementar codigo (Bash/JavaScript) |
+| `reviewer` | Code review de cambios |
+| `git-specialist` | Git/GitHub experto — solo Git, NO explora codigo |
+
+### Agentes de dialogo (mode: all)
+
+| Agente | Para que |
+|--------|----------|
+| `systems-analyst` | Analizar requisitos, escribir .opencode/workflow/REQUIREMENTS.md |
+| `design-strategist` | Definir vision de diseno, escribir .opencode/workflow/DESIGN_SYSTEM.md |
+
+### Como cargar una skill
+
+Las skills proveen conocimiento contextual para tareas especificas:
+
+```
+skill({ name: "project-structure" })
+```
+
+Se pueden cargar multiples skills al inicio de una tarea.
+
+## Stack del proyecto
+
+- **CLI tool**: Bash scripting
+- **Runtime**: Node.js (para utilidades JS del generador)
+- **Generador de proyectos**: Bash + Node.js
+- **Proyectos generados**: Node.js + Express + ESM
+
+## Reglas generales
+
+- NO modifiques codigo sin entenderlo primero
+- El flujo es un LOOP: si los quality gates fallan, vuelve a implementar
+- Cada subagente escribe SOLO en los archivos que tiene permitido
+- .opencode/workflow/STATE.md debe mantenerse LIVIANO (< 50 lineas)
+- Los detalles de cada US van en .opencode/workflow/history/US-XXX.md
+- No leas historiales previos completos a menos que sean necesarios
+- Define claramente "Definition of Done" antes de marcar como completado

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["AGENTS.md"],
+  "agent": {
+    "architect": {
+      "description": "Planificador tecnico: disena la arquitectura y crea planes detallados antes de implementar",
+      "mode": "subagent",
+      "temperature": 0.3,
+      "permission": {
+        "edit": { "*": "deny", ".opencode/workflow/STATE.md": "allow", ".opencode/workflow/history/*": "allow" },
+        "bash": "deny",
+        "task": "deny",
+        "webfetch": "deny",
+        "websearch": "deny"
+      }
+    },
+    "builder": {
+      "description": "Implementador: escribe codigo Bash/JavaScript siguiendo el plan establecido y las skills cargadas",
+      "mode": "subagent",
+      "permission": {
+        "edit": "allow",
+        "bash": "allow",
+        "task": "deny",
+        "webfetch": "deny",
+        "websearch": "deny"
+      }
+    },
+    "reviewer": {
+      "description": "Code reviewer: revisa calidad, bugs, buenas practicas y seguridad del codigo",
+      "mode": "subagent",
+      "temperature": 0.1,
+      "permission": {
+        "edit": "deny",
+        "bash": "deny",
+        "task": "deny",
+        "webfetch": "deny",
+        "websearch": "deny"
+      }
+    },
+    "systems-analyst": {
+      "description": "Analista de sistemas: conversa contigo para refinar ideas de negocio, define requisitos y escribe .opencode/workflow/REQUIREMENTS.md",
+      "mode": "all",
+      "temperature": 0.6,
+      "permission": {
+        "edit": { "*": "deny", ".opencode/workflow/REQUIREMENTS.md": "allow", ".opencode/workflow/STATE.md": "allow" },
+        "bash": "deny",
+        "task": "deny",
+        "webfetch": "allow",
+        "websearch": "allow"
+      }
+    },
+    "design-strategist": {
+      "description": "Disenador UX/UI estrategico: conversa contigo para definir la vision de diseno, paleta de colores, tipografia y estilo visual. Escribe .opencode/workflow/DESIGN_SYSTEM.md.",
+      "mode": "all",
+      "temperature": 0.7,
+      "permission": {
+        "edit": { "*": "deny", ".opencode/workflow/DESIGN_SYSTEM.md": "allow", ".opencode/workflow/STATE.md": "allow" },
+        "bash": "deny",
+        "task": "deny",
+        "webfetch": "allow",
+        "websearch": "allow"
+      }
+    },
+    "designer": {
+      "description": "Disenador UX/UI tecnico: aplica los tokens de .opencode/workflow/DESIGN_SYSTEM.md, revisa fidelidad visual de componentes.",
+      "mode": "subagent",
+      "temperature": 0.4,
+      "permission": {
+        "edit": { "*": "deny", ".opencode/workflow/DESIGN_SYSTEM.md": "allow", ".opencode/workflow/STATE.md": "allow", ".opencode/workflow/history/*": "allow" },
+        "bash": "deny",
+        "task": "deny",
+        "webfetch": "allow",
+        "websearch": "allow"
+      }
+    },
+    "git-specialist": {
+      "description": "Git Specialist - operador experto en Git local + GitHub remoto. NO explora codigo, solo Git y GitHub. Disponible para dialogo directo.",
+      "mode": "all",
+      "temperature": 0.0,
+      "permission": {
+        "edit": "deny",
+        "bash": {
+          "*": "deny",
+          "git *": "allow"
+        },
+        "task": "deny",
+        "webfetch": "deny",
+        "websearch": "deny"
+      }
+    }
+  },
+  "permission": {
+    "edit": "allow",
+    "bash": "allow",
+    "task": "allow"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,12 @@
   "bin": {
     "hexagonizer": "./bin/hexagon"
   },
+  "files": [
+    "bin/",
+    "generator/",
+    "scripts/",
+    "README.md"
+  ],
   "keywords": [
     "cli",
     "hexagon",


### PR DESCRIPTION
## Cambios

Se agrega configuracion multi-agente de OpenCode para trabajar con agentes especializados:

### opencode.json
- 7 agentes configurados: architect, builder, reviewer, systems-analyst, design-strategist, designer, git-specialist
- Permisos granular por agente (path-based para workflow files)

### AGENTS.md
- Quality Gate Loop: SETUP -> PLAN -> IMPLEMENT -> QUALITY GATES -> FINALIZE -> GIT
- Instrucciones para delegar a subagentes via Task tool

### .opencode/agents/ (7 agentes)
- Cada agente con instrucciones especificas y permisos

### .opencode/skills/ (4 skills)
- **design-principles**: SOLID, KISS, DRY, YAGNI (universal)
- **design-patterns**: Factory, Repository, Use Case, Value Object (adaptado a JS)
- **error-handling**: AppError hierarchy + Express global handler
- **project-structure**: Documenta la estructura real de hexagonizer y los proyectos generados

### .opencode/workflow/
- STATE.md, REQUIREMENTS.md, DESIGN_SYSTEM.md, history/

### npm exclusion
- `.npmignore` + campo `"files"` en package.json para que opencode config no se publique en npm

### Archivos creados: 20
### Lineas: +1016