### PR TITLE
docs: add project documentation in docs/

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# Hexagonizer Docs
+
+Hexagonizer es un CLI que genera proyectos Node.js con arquitectura hexagonal y entidades CRUD completas en segundos.
+
+## Indice
+
+| Documento | Para que |
+|-----------|----------|
+| [Getting Started](getting-started.md) | Instalacion, primer uso, ejemplos rapidos |
+| [CLI Reference](cli-reference.md) | Todos los comandos, flags y submenus |
+| [Architecture](architecture.md) | Como funciona hexagonizer internamente |
+| [Project Generator](project-generator.md) | Que crea `hexagonizer init` (Express + middlewares + Docker) |
+| [Entity Generator](entity-generator.md) | Que crea `hexagonizer entity` (dominio, casos de uso, API) |
+| [Development](development.md) | Guia para contribuir al desarrollo de hexagonizer |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,51 @@
+# Architecture
+
+Hexagonizer es un CLI escrito en Bash que orquesta generadores de codigo Node.js. Su arquitectura es un **pipeline secuencial de modulos numerados**.
+
+```
+bin/hexagon (menu interactivo)
+  |
+  +-- scripts/init-project.sh (proyecto nuevo)
+  |     |
+  |     +-- generator/project/00-parse-args.sh
+  |     +-- generator/project/01-check-node-and-npm.sh
+  |     +-- generator/project/02-init-npm-and-install-deps.sh
+  |     +-- generator/project/03-create-folders.sh
+  |     +-- generator/project/04-create-base-files.sh
+  |     +-- ... hasta 14-setup-docker.sh
+  |
+  +-- scripts/entity-generator.sh (entidad nueva)
+        |
+        +-- generator/entity/00-helpers.sh
+        +-- generator/entity/01-parse-args.sh
+        +-- generator/entity/02-load-schema.sh
+        +-- generator/entity/03-generate-domain.sh
+        +-- ... hasta 15-update-index.sh
+```
+
+## Pipeline de modulos
+
+Cada modulo es un script `.sh` independiente que:
+
+1. Se ejecuta en orden numerico (00 → 15)
+2. Lee variables de entorno exportadas por modulos anteriores
+3. Crea archivos o modifica el proyecto
+4. Exporta nuevas variables si es necesario
+
+## Variables compartidas
+
+| Variable | Origen | Uso |
+|----------|--------|-----|
+| `AUTO_YES` | `00-parse-args.sh` (project) | Salta confirmaciones |
+| `AUTO_CONFIRM` | `01-parse-args.sh` (entity) | Salta confirmaciones |
+| `entity` | `02-load-schema.sh` | Nombre en snake_case |
+| `EntityPascal` | `02-load-schema.sh` | Nombre en PascalCase |
+| `PARSED_FIELDS` | `02-load-schema.sh` | JSON con campos parseados |
+| `SCHEMA_CONTENT` | `02-load-schema.sh` | Schema JSON original |
+
+## Convenciones de codigo
+
+- **Bash**: `set -e`, `set -u`, colores `RED/GREEN/YELLOW/BLUE/NC`, funcion `log()` con timestamp
+- **JavaScript generado**: ESM (`import`/`export`), `"type": "module"` en package.json
+- **Nombres**: PascalCase para clases, camelCase para funciones, snake_case para archivos y variables Bash
+- **Testing**: Node.js nativo con `assert`, sin frameworks externos

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,45 @@
+# CLI Reference
+
+## Menu principal
+
+Al ejecutar `hexagonizer` se despliega un menu interactivo con 8 opciones:
+
+| # | Opcion | Flag | Comando interno |
+|---|--------|------|-----------------|
+| 1 | Inicializar proyecto | `-y` | `scripts/init-project.sh` |
+| 2 | Generar entidad (interactivo) | — | `scripts/entity-generator.sh` |
+| 3 | Generar entidad rapida | `-y` | `scripts/entity-generator.sh -y` |
+| 4 | Generar desde JSON | `--json` | `scripts/entity-generator.sh --json` |
+| 5 | JSON + Auto-aprobar | `--json -y` | `scripts/entity-generator.sh --json -y` |
+| 6 | Servidor de desarrollo | — | Submenu con comandos npm/docker |
+| 7 | Estadisticas del proyecto | — | Analisis de `src/domain/` |
+| 8 | Salir | — | `exit 0` |
+
+## Flags
+
+| Flag | Efecto |
+|------|--------|
+| `-y`, `--yes` | Auto-responde "si" a todas las confirmaciones |
+| `--json` | Usa schema JSON file en vez de modo interactivo |
+
+## Submenu Servidor (opcion 6)
+
+| # | Comando |
+|---|---------|
+| 1 | `npm start` |
+| 2 | `npm run dev` |
+| 3 | `npm run test` |
+| 4 | `docker build -t app .` |
+| 5 | `docker run -p 3000:3000 app` |
+| 6 | `docker-compose up` |
+| 7 | `docker-compose up -d` |
+| 8 | `docker-compose down` |
+| 9 | `npm install` |
+| 10 | `npm run lint` |
+| 11 | Volver al menu principal |
+
+## Comportamiento
+
+- **Deteccion de proyecto**: hexagonizer busca `package.json` en el directorio actual y padres para detectar si estas dentro de un proyecto generado
+- **Modo JSON**: Busca schemas en `generator/entity/entity-schemas/` o permite ingresar una ruta personalizada
+- **Estadisticas**: Cuenta entidades en `src/domain/`, archivos JS/TS, tests y dependencias npm

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,77 @@
+# Development
+
+Guia para contribuir al desarrollo del CLI hexagonizer.
+
+## Stack
+
+- **CLI principal**: Bash scripting
+- **Utilidades**: Node.js (procesamiento de schemas JSON)
+- **Codigo generado**: Node.js + Express + ESM
+
+## Estructura del proyecto
+
+```
+bin/hexagon              # Entry point del CLI (menu interactivo)
+scripts/
+  init-project.sh        # Orquestador de generacion de proyectos
+  entity-generator.sh    # Orquestador de generacion de entidades
+generator/
+  project/               # Modulos del generador de proyectos (00-14)
+  entity/                # Modulos del generador de entidades (00-15)
+  common/                # Funciones compartidas entre generadores
+  utils/                 # Utilidades Node.js (parseo de schemas)
+```
+
+## Convenciones de codigo
+
+### Bash
+- Usar `set -e` y `set -u` en scripts
+- Funcion `log(level, message)` con colores y timestamp
+- Variables en UPPER_CASE para configuracion
+- Citar variables siempre: `"$var"`
+- Preferir `[[ ... ]]` sobre `[ ... ]`
+
+### Modulos generadores
+- Numeracion de 2 digitos (`00-`, `01-`, etc.) para orden explicito
+- Cada modulo es independiente y ejecutable por separado
+- Variables compartidas via `export`
+- `main()` function al final para ejecucion directa o via source
+
+### JavaScript generado
+- ESM: `import`/`export`, `"type": "module"`
+- Clases para entidades, factories, use cases, repositorios
+- Funciones para controladores
+- Tests con `assert` nativo
+
+## Agregar un nuevo modulo
+
+1. Crea `generator/<area>/NN-nombre.sh`
+2. Sigue la numeracion existente
+3. Usa las variables compartidas del pipeline
+4. Manten las convenciones de logging y colores
+5. Si toca el index, actualiza el orquestador correspondiente
+
+## Probar cambios
+
+```bash
+# Ejecutar el CLI localmente
+node bin/hexagon
+
+# O directamente los generadores
+bash scripts/init-project.sh -y
+bash scripts/entity-generator.sh -y
+```
+
+## Schemas de entidad
+
+Los schemas JSON de ejemplo estan en `generator/entity/entity-schemas/`.
+Para agregar uno nuevo, crea un archivo JSON siguiendo el formato documentado en [entity-generator.md](entity-generator.md).
+
+## Publicacion npm
+
+```bash
+npm publish
+```
+
+El campo `"files"` en `package.json` controla que se publica: solo `bin/`, `generator/`, `scripts/` y `README.md`.
+Los archivos de configuracion de opencode (`opencode.json`, `AGENTS.md`, `.opencode/`) quedan excluidos.

--- a/docs/entity-generator.md
+++ b/docs/entity-generator.md
@@ -1,0 +1,115 @@
+# Entity Generator
+
+`hexagonizer entity` genera una entidad completa con dominio, casos de uso, API REST y tests. El generador recorre **15 modulos** en pipeline.
+
+## Estructura generada por entidad
+
+Tomando `Product` como ejemplo:
+
+```
+src/
+├── domain/
+│   └── product/
+│       ├── product.js               # Clase de dominio con getters/setters
+│       ├── product-factory.js       # Factory (create, createMany, createDefault)
+│       ├── product-validation.js    # Validacion de campos
+│       ├── product-constants.js     # Constantes, enums, config
+│       └── mocks.js                 # Datos de prueba
+├── application/
+│   └── product/
+│       ├── use-cases/
+│       │   ├── create-product.js    # CreateProduct
+│       │   ├── get-product.js       # GetProduct
+│       │   ├── update-product.js    # UpdateProduct
+│       │   ├── delete-product.js    # DeleteProduct
+│       │   ├── deactivate-product.js # DeactivateProduct
+│       │   └── list-product.js      # ListProducts (con paginacion)
+│       └── services/
+│           ├── get-active-product.js
+│           ├── get-inactive-product.js
+│           └── count-product.js
+├── infrastructure/
+│   └── product/
+│       ├── in-memory-product-repository.js  # Repositorio en memoria
+│       └── database-product-repository.js   # Esqueleto para BD real
+└── interfaces/
+    └── http/
+        └── product/
+            ├── product.controller.js  # Controladores Express
+            ├── product.routes.js      # Router CRUD
+            └── query-product-config.js # Config de filtros/busqueda/orden
+tests/
+└── application/
+    └── product/
+        ├── create-product.test.js
+        ├── get-product.test.js
+        ├── update-product.test.js
+        ├── delete-product.test.js
+        └── deactivate-product.test.js
+```
+
+## Pipeline de generacion
+
+| Modulo | Que crea |
+|--------|----------|
+| `03-generate-domain.sh` | Clase de dominio con constructor, getters/setters, `toJSON()`, `activate()`/`deactivate()` |
+| `04-generate-validation.sh` | Funcion `validateProduct(data)` con validacion de tipos, required, min/max, email, enum |
+| `05-generate-factory.sh` | `ProductFactory.create(data)`, `createMany()`, `createDefault()` |
+| `06-generate-constants.sh` | Constantes (`DEFAULT_ACTIVE`, `PRODUCT_CONFIG`), enums, y mocks con datos de prueba |
+| `07-generate-repository.sh` | `InMemoryProductRepository` (funcional) y `DatabaseProductRepository` (esqueleto) |
+| `08-generate-usecases.sh` | 6 casos de uso CRUD + list con paginacion (`{ data, meta }`) |
+| `09-generate-services.sh` | Filtros por estado activo/inactivo, contadores con stats |
+| `10-generate-controller.sh` | Controladores Express que instancian use cases y responden JSON |
+| `11-generate-routes.sh` | Router con `POST /`, `GET /`, `GET /:id`, `PUT /:id`, `DELETE /:id`, `PATCH /:id/deactivate` |
+| `12-generate-query-entity-config.sh` | Config de campos buscables, ordenables y filtrables |
+| `14-generate-tests.sh` | 5 tests con `assert` nativo de Node.js |
+| `15-update-index.sh` | Parchea `src/index.js` registrando la nueva ruta |
+
+## Formato del schema JSON
+
+```json
+{
+  "name": "Product",
+  "fields": [
+    { "name": "name", "required": true },
+    { "name": "price", "type": "number", "default": 0 },
+    { "name": "email", "type": "string", "format": "email" },
+    { "name": "category", "enum": ["electronics", "clothing"] },
+    { "name": "password", "sensitive": true }
+  ],
+  "methods": [
+    { "name": "decreaseStock", "params": ["qty"], "body": "this._stock -= qty;" }
+  ]
+}
+```
+
+### Campos base automaticos
+
+Siempre se agregan (aunque no esten en el schema): `id`, `active`, `createdAt`, `updatedAt`, `deletedAt`, `ownedBy`.
+
+### Flags del schema
+
+| Flag | Default | Efecto |
+|------|---------|--------|
+| `timestamps` | true | Agrega createdAt, updatedAt |
+| `softDelete` | true | Agrega deletedAt |
+| `ownership` | true | Agrega ownedBy, createdBy, updatedBy |
+
+## Convenciones de nombres
+
+| Contexto | Convencion | Ejemplo |
+|----------|------------|---------|
+| Variable Bash | snake_case | `entity`, `EntityPascal` |
+| Clase JS | PascalCase | `CreateProduct`, `InMemoryProductRepository` |
+| Archivo JS | kebab-case | `in-memory-product-repository.js` |
+| Ruta API | singular | `/product` |
+| Tabla BD | plural + 's' | `products` |
+| Metodo de repositorio | camelCase | `findById`, `save`, `deleteById` |
+
+## Tests
+
+- Framework: `assert` nativo de Node.js
+- 5 tests por entidad: create, get, update, delete, deactivate
+- Cada test es un async IIFE auto-ejecutable
+- Usan `InMemoryRepository` directamente
+- Se ejecutan con: `npm test` o directamente `node tests/application/product/create-product.test.js`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,61 @@
+# Getting Started
+
+## Instalacion
+
+```bash
+npm install -g hexagonizer
+```
+
+## Primer proyecto
+
+```bash
+# Crear y entrar al directorio
+mkdir mi-app && cd mi-app
+
+# Inicializar proyecto con arquitectura hexagonal
+hexagonizer
+```
+
+Selecciona la opcion **1 - Inicializar proyecto** y el CLI creara toda la estructura.
+
+## Agregar una entidad
+
+Dentro del proyecto generado:
+
+```bash
+hexagonizer
+```
+
+Selecciona la opcion **2 - Generar entidad** e ingresa el nombre (ej: `Product`).
+O usa la opcion **4 - Generar desde JSON** pasando un schema predefinido.
+
+## Desarrollo
+
+El proyecto generado incluye:
+
+```bash
+npm run dev    # Servidor con nodemon (hot reload)
+npm start      # Servidor en produccion
+npm test       # Ejecutar tests
+```
+
+## Ejemplo rapido: Product
+
+```bash
+# 1. Crear proyecto
+mkdir tienda && cd tienda
+hexagonizer   # Opcion 1
+
+# 2. Agregar entidad Product
+hexagonizer   # Opcion 2, nombre: "Product"
+
+# 3. Iniciar servidor
+hexagonizer   # Opcion 6 > opcion 2 (npm run dev)
+# Servidor en http://localhost:3000
+
+# 4. Probar API
+curl http://localhost:3000/product              # GET listar
+curl -X POST http://localhost:3000/product \    # POST crear
+  -H "Content-Type: application/json" \
+  -d '{"name":"Laptop","price":999}'
+```

--- a/docs/project-generator.md
+++ b/docs/project-generator.md
@@ -1,0 +1,77 @@
+# Project Generator
+
+`hexagonizer init` crea un proyecto Node.js + Express listo para desarrollar.
+
+## Estructura generada
+
+```
+mi-proyecto/
+├── src/
+│   ├── index.js                     # Entry point: crea Server, monta rutas
+│   ├── config/
+│   │   ├── server.js                # Clase Server: middlewares + rutas + start
+│   │   └── database.js              # Placeholder de configuracion DB
+│   ├── domain/                      # Entidades (vacio hasta generar)
+│   ├── application/                 # Casos de uso (vacio hasta generar)
+│   ├── infrastructure/
+│   │   └── database/
+│   │       └── database.js          # Placeholder de conexion DB
+│   ├── interfaces/
+│   │   └── http/
+│   │       ├── health/
+│   │       │   └── health.routes.js # GET /health → { status: 'ok' }
+│   │       ├── public/
+│   │       │   └── public.routes.js # GET /info → metadata del proyecto
+│   │       └── middlewares/         # Auth, roles, error handler, etc.
+│   ├── utils/
+│   │   ├── query-utils.js           # applyFilters, applySearch, applySort, applyPagination
+│   │   └── wrap-router-with-flexible-middlewares.js
+│   └── public/
+│       └── index.html               # Landing page animada con hexagono 3D
+├── tests/
+│   └── application/                 # Tests de casos de uso
+├── Dockerfile                       # node:18, npm install, expone 3000
+├── docker-compose.yml               # Servicio con hot-reload volumem
+├── .dockerignore
+└── package.json
+```
+
+## Server class
+
+```javascript
+class Server {
+  constructor({ routes, middlewares })
+  // 1. setupMiddlewares() → express.json(), cors, helmet, morgan, custom mws
+  // 2. setupRoutes() → monta cada ruta con wrapRouterWithFlexibleMiddlewares
+  // 3. start(port) → app.listen(port)
+}
+```
+
+## Middlewares base (opcionales)
+
+Si se confirma durante `init`, se generan:
+
+| Middleware | Funcion |
+|-----------|---------|
+| `auth.middleware.js` | Valida Bearer token |
+| `check-role.middleware.js` | `checkRole()` y `checkRoleOrOwner()` |
+| `error-handler.middleware.js` | Captura errores, responde JSON |
+| `rate-limiter.middleware.js` | Limita 100 req / 15 min |
+| `request-logger.middleware.js` | Log de method + URL |
+| `sanitize.middleware.js` | XSS clean + mongo sanitize |
+
+## Router wrapper
+
+`wrapRouterWithFlexibleMiddlewares(router, config)` permite aplicar middlewares globales, por ruta o excluyendo paths especificos usando `path-to-regexp`.
+
+## Dependencias instaladas
+
+**Produccion**: `express`, `path-to-regexp`, `cors`, `helmet`, `morgan`, `dotenv`
+
+**Desarrollo**: `nodemon`
+
+## Docker
+
+- `Dockerfile` con Node 18
+- `docker-compose.yml` con volumen montado para desarrollo en caliente
+- Acceso rapido desde el menu de hexagonizer (opcion 6)


### PR DESCRIPTION
## Cambios

Nueva carpeta `docs/` con documentacion completa del proyecto:

- **getting-started.md**: Instalacion, primer proyecto, ejemplo Product
- **cli-reference.md**: Los 8 comandos del menu, flags, submenu servidor
- **architecture.md**: Pipeline de modulos, variables compartidas
- **project-generator.md**: Express Server class, middlewares, Docker
- **entity-generator.md**: Pipeline 15 modulos, naming conventions, JSON schemas
- **development.md**: Guia para contribuir

### Archivos: 7
### Lineas: +440